### PR TITLE
Allow not specifying mandatory env variables

### DIFF
--- a/.github/workflows/publish-gptstonks-api.yaml
+++ b/.github/workflows/publish-gptstonks-api.yaml
@@ -1,0 +1,17 @@
+name: Publish gptstonks-api to PyPI
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - ".github/workflows/_publish_package.yaml"
+      - ".github/workflows/publish-gptstonks-api.yaml"
+      - "projects/gptstonks_api/**"
+  workflow_dispatch: # Allows to trigger the workflow manually in GitHub UI
+
+jobs:
+  publish-gptstonks-wrappers:
+    uses: ./.github/workflows/_publish_package.yaml
+    with:
+      working-directory: projects/gptstonks_api
+    secrets: inherit

--- a/projects/gptstonks_api/gptstonks/api/constants/env.py
+++ b/projects/gptstonks_api/gptstonks/api/constants/env.py
@@ -8,9 +8,18 @@ The list of env variables is provided in [Configuration with environment variabl
 """
 
 import os
+import warnings
 
-MONGO_URI: str = os.environ["MONGO_URI"]
-MONGO_DBNAME: str = os.environ["MONGO_DBNAME"]
+try:
+    MONGO_URI: str = os.environ["MONGO_URI"]
+except KeyError:
+    warnings.warn("MONGO_URI env variable not provided")
+    MONGO_URI = None
+try:
+    MONGO_DBNAME: str = os.environ["MONGO_DBNAME"]
+except KeyError:
+    warnings.warn("MONGO_DBNAME env variable not provided")
+    MONGO_DBNAME = None
 DEBUG_API: str | None = os.getenv("DEBUG_API")
 AUTOLLAMAINDEX_VSI_GDRIVE_URI: str | None = os.getenv("AUTOLLAMAINDEX_VSI_GDRIVE_URI")
 AUTOLLAMAINDEX_EMBEDDING_MODEL_ID: str = os.getenv(
@@ -22,7 +31,11 @@ AUTOLLAMAINDEX_SIMILARITY_POSTPROCESSOR_CUTOFF: float = float(
 AUTOLLAMAINDEX_REMOVE_METADATA_POSTPROCESSOR: str | None = os.getenv(
     "AUTOLLAMAINDEX_REMOVE_METADATA_POSTPROCESSOR"
 )
-AUTOLLAMAINDEX_VSI_PATH: str = os.environ["AUTOLLAMAINDEX_VSI_PATH"]
+try:
+    AUTOLLAMAINDEX_VSI_PATH: str = os.environ["AUTOLLAMAINDEX_VSI_PATH"]
+except KeyError:
+    warnings.warn("AUTOLLAMAINDEX_VSI_PATH env variable not provided")
+    AUTOLLAMAINDEX_VSI_PATH = None
 AUTOLLAMAINDEX_LLM_CONTEXT_WINDOW: int = int(os.getenv("AUTOLLAMAINDEX_LLM_CONTEXT_WINDOW", 4096))
 AUTOLLAMAINDEX_QA_TEMPLATE: str | None = os.getenv("AUTOLLAMAINDEX_QA_TEMPLATE")
 AUTOLLAMAINDEX_REFINE_TEMPLATE: str | None = os.getenv("AUTOLLAMAINDEX_REFINE_TEMPLATE")
@@ -45,7 +58,11 @@ AGENT_EARLY_STOPPING_METHOD: str = os.getenv("AGENT_EARLY_STOPPING_METHOD", "for
 LLM_TEMPERATURE: float = float(os.getenv("LLM_TEMPERATURE", 0.1))
 LLM_MAX_TOKENS: int = int(os.getenv("LLM_MAX_TOKENS", 256))
 LLM_TOP_P: float = float(os.getenv("LLM_TOP_P", 1.0))
-LLM_MODEL_ID: str = os.environ["LLM_MODEL_ID"]
+try:
+    LLM_MODEL_ID: str = os.environ["LLM_MODEL_ID"]
+except KeyError:
+    warnings.warn("LLM_MODEL_ID env variable not provided")
+    LLM_MODEL_ID = None
 LLM_CHAT_MODEL_SYSTEM_MESSAGE: str = os.getenv(
     "LLM_CHAT_MODEL_SYSTEM_MESSAGE", "You write concise and complete answers."
 )
@@ -57,8 +74,16 @@ LLM_HF_DEVICE_MAP: str | None = os.getenv("LLM_HF_DEVICE_MAP")
 LLM_HF_BITS: int = int(os.getenv("LLM_HF_GPTQ_BITS", 4))
 LLM_HF_DISABLE_EXLLAMA: bool = bool(os.getenv("LLM_HF_DISABLE_EXLLAMA", False))
 LLM_HF_TRUST_REMOTE_CODE: bool = bool(os.getenv("LLM_HF_TRUST_REMOTE_CODE"))
-OPENBBCHAT_TOOL_DESCRIPTION: str = os.environ["OPENBBCHAT_TOOL_DESCRIPTION"]
+try:
+    OPENBBCHAT_TOOL_DESCRIPTION: str = os.environ["OPENBBCHAT_TOOL_DESCRIPTION"]
+except KeyError:
+    warnings.warn("OPENBBCHAT_TOOL_DESCRIPTION env variable not provided")
+    OPENBBCHAT_TOOL_DESCRIPTION = None
 SEARCH_TOOL_DESCRIPTION: str | None = os.getenv("SEARCH_TOOL_DESCRIPTION")
 WIKIPEDIA_TOOL_DESCRIPTION: str | None = os.getenv("WIKIPEDIA_TOOL_DESCRIPTION")
 CUSTOM_GPTSTONKS_PREFIX: str | None = os.getenv("CUSTOM_GPTSTONKS_PREFIX")
-WORLD_KNOWLEDGE_TOOL_DESCRIPTION: str = os.environ["WORLD_KNOWLEDGE_TOOL_DESCRIPTION"]
+try:
+    WORLD_KNOWLEDGE_TOOL_DESCRIPTION: str = os.environ["WORLD_KNOWLEDGE_TOOL_DESCRIPTION"]
+except KeyError:
+    warnings.warn("WORLD_KNOWLEDGE_TOOL_DESCRIPTION env variable not provided")
+    WORLD_KNOWLEDGE_TOOL_DESCRIPTION = None


### PR DESCRIPTION
Useful when importing from constants from other packages and not all mandatory vars are needed. A warning is generated instead of an error to make clear the env is not being specified.

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

Allows not specifying mandatory env variables from the API, which is useful when importing API constants from other libraries. A warning is generated instead to make clear what envs are not being declared.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
